### PR TITLE
CSA-N4 Test pr 3

### DIFF
--- a/script.js
+++ b/script.js
@@ -17,7 +17,7 @@ import fetch from "node-fetch";
 console.log("~~~~~~~~~~~~")
 console.log("PR test 3")
 console.log("~~~~~~~~~~~~")
-console.log("PR test 0.4")
+console.log("PR test 0.5")
 
 // let cycleKeys = cycleKey.split(",")
 // console.log(cycleKeys)

--- a/script.js
+++ b/script.js
@@ -17,7 +17,7 @@ import fetch from "node-fetch";
 console.log("~~~~~~~~~~~~")
 console.log("PR test 3")
 console.log("~~~~~~~~~~~~")
-console.log("PR test 0.5")
+console.log("PR test 0.6")
 
 // let cycleKeys = cycleKey.split(",")
 // console.log(cycleKeys)

--- a/script.js
+++ b/script.js
@@ -17,7 +17,7 @@ import fetch from "node-fetch";
 console.log("~~~~~~~~~~~~")
 console.log("PR test 3")
 console.log("~~~~~~~~~~~~")
-console.log("PR test 0.3")
+console.log("PR test 0.4")
 
 // let cycleKeys = cycleKey.split(",")
 // console.log(cycleKeys)

--- a/script.js
+++ b/script.js
@@ -17,7 +17,7 @@ import fetch from "node-fetch";
 console.log("~~~~~~~~~~~~")
 console.log("PR test 3")
 console.log("~~~~~~~~~~~~")
-console.log("PR test 0.6")
+console.log("PR test 0.7")
 
 // let cycleKeys = cycleKey.split(",")
 // console.log(cycleKeys)


### PR DESCRIPTION
### 📝 Description
- please describe the purpose of this pull request ...

### 🚀 New Features

📈 DataDog:

[[CSI-xxx](https://justeattakeaway.atlassian.net/browse/CSI-xxx)][k6-core][vx.x.x][Data Dog] [Marcos]Send logs ...

🔧 one-test-suite:
- List of tasks from jira ...

📂 Zephyr Scale:
- List of tasks from jira ...

📖 Documentation:
- List of tasks from jira ...

drawio: [one-test-suite.drawio](https://app.diagrams.net/#G1DBgh-RX5W77QYX-Cnbso4DTskmzCGJ0p#%7B%22pageId%22%3A%22VTrIVil6MW1F_naaKxXM%22%7D)

Confluence: [one-test-suite [DataDog + Zephyr Scale + k6] ](https://justeattakeaway.atlassian.net/wiki/spaces/CSI/pages/6511100401/k6-core+DataDog+Zephyr+Scale+k6)

Presentation: [ one-test-suite [release x.x.x] Month 2024 (v1)](https://docs.google.com/presentation/d/1N4Yoapg3HI3ZKJ4lVj7Qn7hwSvKvQoss1KU9fdEovq4/edit#slide=id.p)

♻️ TestCase coverage:
- List of tasks from jira ...

🔁 CI
- List of tasks from jira ...

🔩 Refactor
- List of tasks from jira ...

### ✅ Checklist checks
- [ ] I have tested the changes locally and in run workflow and verified that they work as intended.
- [ ] I have verified that after the automatic execution Test Suite -> metrics are correctly displayed in DataDog.
- [ ] I have verified that after the automatic execution Test Suite -> metrics are correctly displayed in Zephyr Scale.
- [ ] I made sure that after running multiple TestCycles at the same time, they are executed in parallel -> metrics are delivered and displayed correctly for each TestCycle in DataDog. The current status of the run is displayed in Zephyr Scale.

### ❎ Checklist deploy

- [ ] Update -> README
- [ ] Update -> Sequence diagram
- [ ] Uploaded and saved the new version of the Data Dog dashboard to the project at the path: one-test-suite/datadog/dashboards

### 💫 Checks:
- Link ...

### 🚢 Successful run action:
- Link ...

### 🐶 DataDog: [one-test-suite [release-vx.x.x][stable]](https://app.datadoghq.eu/dashboard/wmk-b9h-pec/k6-core-master?fromUser=false&refresh_mode=sliding&view=spans&from_ts=1715218224129&to_ts=1715219124129&live=true)
